### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:each"
   },
-  "repository": "",
+  "repository": "https://github.com/xamoom/ember-shopify.git",
   "engines": {
     "node": ">= 0.12.0"
   },


### PR DESCRIPTION
This lets the NPM registry pick it up, so downstream stuff like [Ember Observer](https://emberobserver.com/) can display/use it.